### PR TITLE
Support figure environment

### DIFF
--- a/src/latex-to-ast/environment/common.ts
+++ b/src/latex-to-ast/environment/common.ts
@@ -44,12 +44,12 @@ export const BeginEnvironment = (
 
 export const EndEnvironment = (context: Context): Parsimmon.Parser<null> =>
   Parsimmon((input, i) => {
-    const pattern = context.name.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
-    const m = input.slice(i).match(new RegExp(`^\\\\end\\{${pattern}\\}`));
+    const p = context.name.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+    const m = input.slice(i).match(new RegExp(`^\\\\end\\{${p}\\}`));
     if (m !== null) {
       return Parsimmon.makeSuccess(i + m[0].length, null);
     } else {
-      return Parsimmon.makeFailure(i, `\\end{${pattern}}`);
+      return Parsimmon.makeFailure(i, `\\end{${p}}`);
     }
   });
 

--- a/src/latex-to-ast/environment/common.ts
+++ b/src/latex-to-ast/environment/common.ts
@@ -44,11 +44,12 @@ export const BeginEnvironment = (
 
 export const EndEnvironment = (context: Context): Parsimmon.Parser<null> =>
   Parsimmon((input, i) => {
-    const m = input.slice(i).match(new RegExp(`^\\\\end\\{${context.name}\\}`));
+    const pattern = context.name.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+    const m = input.slice(i).match(new RegExp(`^\\\\end\\{${pattern}\\}`));
     if (m !== null) {
       return Parsimmon.makeSuccess(i + m[0].length, null);
     } else {
-      return Parsimmon.makeFailure(i, `\\end{${context.name}}`);
+      return Parsimmon.makeFailure(i, `\\end{${pattern}}`);
     }
   });
 

--- a/src/latex-to-ast/environment/figure.ts
+++ b/src/latex-to-ast/environment/figure.ts
@@ -14,9 +14,27 @@
  * You should have received a copy of the GNU General Public License
  * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
  */
-export { DisplayMath } from "./displaymath";
-export { Environment } from "./common";
-export { Figure } from "./figure";
-export { InlineMath } from "./inlinemath";
-export { Document } from "./document";
-export { List } from "./list";
+
+import Parsimmon from "parsimmon";
+import { Rules } from "../rules";
+import { BeginEnvironment, EndEnvironment, EnvironmentNode } from "./common";
+
+export const Figure = (r: Rules) => {
+  const context = { name: "" };
+  const body = Parsimmon.seqMap(
+    Parsimmon.index,
+    Parsimmon.index,
+    (start, end) => ({
+      start,
+      end,
+      name: "figure"
+    })
+  );
+  return Parsimmon.seqObj<EnvironmentNode>(
+    ["name", BeginEnvironment("figure\\\*?", context)],
+    ["arguments", Parsimmon.alt(r.Option, r.Argument).many()],
+    Parsimmon.whitespace,
+    ["body", body],
+    EndEnvironment(context)
+  ).node("environment");
+};

--- a/src/latex-to-ast/index.ts
+++ b/src/latex-to-ast/index.ts
@@ -167,6 +167,13 @@ export const parse = (text: string) => {
                 children: node.value.arguments.concat(node.value.body)
               });
               break;
+            case "figure":
+              this.update({
+                ...tmp,
+                type: ASTNodeTypes.Image,
+                children: node.value.arguments.concat(node.value.body)
+              });
+              break;
             default:
               this.update({
                 ...tmp,

--- a/src/latex-to-ast/latex.ts
+++ b/src/latex-to-ast/latex.ts
@@ -19,6 +19,7 @@ import Parsimmon from "parsimmon";
 import {
   Environment,
   DisplayMath,
+  Figure,
   InlineMath,
   Document,
   List
@@ -35,6 +36,7 @@ export const LaTeX = Parsimmon.createLanguage({
   Document,
   List,
   DisplayMath,
+  Figure,
   InlineMath,
   Command,
   Verbatim,

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -76,6 +76,19 @@ describe("Parsimmon AST", async () => {
     const ast = LaTeX.Program.tryParse(code);
     expect(ast.value[0].value.body.value.length).toBe(2);
   });
+  test("figure environment", async () => {
+    const code = `\\begin{figure}
+        \\includegraphics[width=5cm]{somefigure.png}
+        \\caption{This is a caption}
+        \\end{figure}
+        \\begin{figure*}
+        \\includegraphics[width=5cm]{anotherfigure.png}
+        \\caption{This is an another caption}
+        \\end{figure*}`;
+    const ast = LaTeX.Program.tryParse(code);
+    expect(ast.value[0].value.name).toBe("figure");
+    expect(ast.value[2].value.name).toBe("figure*");
+  });
 });
 
 describe("TxtNode AST", async () => {


### PR DESCRIPTION
#1 のうち、まずはfigure環境の部分を追加しました。
普通の`figure`環境と、2段組に1段組の図を挿入する時使用する`figure*`環境に対応しています。

`figure*`は以下の部分でそのままRegExpにするとアスタリスクがメタ文字になってしまうので、先にエスケープするようにしました。

https://github.com/ta2gch/textlint-plugin-latex2e/blob/571e268eaef651dee094920409219156f1d6bf93/src/latex-to-ast/environment/common.ts#L45-L47
