### PR TITLE
Fix error in nested environments

### DIFF
--- a/src/latex-to-ast/environment/document.ts
+++ b/src/latex-to-ast/environment/document.ts
@@ -19,7 +19,7 @@ import { EnvironmentNode, BeginEnvironment, EndEnvironment } from "./common";
 import { Rules } from "../rules";
 
 export const Document = (r: Rules) => {
-  const context = { name: "" };
+  const context = { name: "", parents: [] };
   const option = r.Option;
   const argument = r.Argument;
   const body = r.Program.map(parentNode => {

--- a/src/latex-to-ast/environment/figure.ts
+++ b/src/latex-to-ast/environment/figure.ts
@@ -20,7 +20,7 @@ import { Rules } from "../rules";
 import { BeginEnvironment, EndEnvironment, EnvironmentNode } from "./common";
 
 export const Figure = (r: Rules) => {
-  const context = { name: "" };
+  const context = { name: "", parents: [] };
   const body = Parsimmon.seqMap(
     Parsimmon.index,
     Parsimmon.index,

--- a/src/latex-to-ast/environment/list.ts
+++ b/src/latex-to-ast/environment/list.ts
@@ -21,7 +21,7 @@ import { CommandNode } from "../command";
 import { BeginEnvironment, EndEnvironment, EnvironmentNode } from "./common";
 
 export const List = (r: Rules) => {
-  const context = { name: "" };
+  const context = { name: "", parents: [] };
   const item = Parsimmon.seqObj<CommandNode>(
     ["name", Parsimmon.regex(/\\(i+tem)/, 1)],
     ["arguments", r.Program.map(_ => [_])]

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -89,6 +89,20 @@ describe("Parsimmon AST", async () => {
     expect(ast.value[0].value.name).toBe("figure");
     expect(ast.value[2].value.name).toBe("figure*");
   });
+  test("nested environments", async () => {
+    const code = `\\begin{figure}
+        \\begin{minipage}{0.45\hsize}
+        \\begin{center}
+        \\includegraphics[width=5cm]{somefigure.png}
+        \\end{center}
+        \\end{minipage}
+        \\end{figure}`;
+    const ast = LaTeX.Program.tryParse(code);
+    const top = ast.value[0].value;
+    expect(top.name).toBe("figure");
+    expect(top.body.value[1].value.name).toBe("minipage");
+    expect(top.body.value[1].value.body.value[1].value.name).toBe("center");
+  });
 });
 
 describe("TxtNode AST", async () => {


### PR DESCRIPTION
fix #4 

`Context`にparentsという配列を追加し、以下の処理を行います。

- `BeginEnvironment()`で`context,name`が既にある場合`context.parents`にpush
- `EndEnvironment()`で`context.parents`からpopして`context,name`に代入

環境をいくつネストしても階層に応じて`context,name`が切り替わるため、パース時点でのエラーを回避できます。