### PR TITLE
Fix inlinemath parser

### DIFF
--- a/src/latex-to-ast/environment/inlinemath.ts
+++ b/src/latex-to-ast/environment/inlinemath.ts
@@ -24,8 +24,8 @@ export const InlineMath = (r: Rules) => {
     Parsimmon.string("\\)")
   );
   const texStyle = r.Program.wrap(
-    Parsimmon.string("$$"),
-    Parsimmon.string("$$")
+    Parsimmon.string("$"),
+    Parsimmon.string("$")
   );
   return Parsimmon.seqObj<EnvironmentNode>(
     ["name", Parsimmon.succeed("inlinemath")],

--- a/src/latex-to-ast/environment/inlinemath.ts
+++ b/src/latex-to-ast/environment/inlinemath.ts
@@ -24,8 +24,8 @@ export const InlineMath = (r: Rules) => {
     Parsimmon.string("\\)")
   );
   const texStyle = r.Program.wrap(
-    Parsimmon.string("$"),
-    Parsimmon.string("$")
+    Parsimmon.regex(/\$[^\$]/),
+    Parsimmon.regex(/\$[^\$]/)
   );
   return Parsimmon.seqObj<EnvironmentNode>(
     ["name", Parsimmon.succeed("inlinemath")],

--- a/src/latex-to-ast/environment/inlinemath.ts
+++ b/src/latex-to-ast/environment/inlinemath.ts
@@ -24,8 +24,8 @@ export const InlineMath = (r: Rules) => {
     Parsimmon.string("\\)")
   );
   const texStyle = r.Program.wrap(
-    Parsimmon.regex(/\$[^\$]/),
-    Parsimmon.regex(/\$[^\$]/)
+    Parsimmon.regex(/\$(?!\$)/),
+    Parsimmon.regex(/\$(?!\$)/)
   );
   return Parsimmon.seqObj<EnvironmentNode>(
     ["name", Parsimmon.succeed("inlinemath")],

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -102,6 +102,16 @@ describe("Parsimmon AST", async () => {
     expect(top.name).toBe("figure");
     expect(top.body.value[1].value.name).toBe("minipage");
     expect(top.body.value[1].value.body.value[1].value.name).toBe("center");
+  test("math", async () => {
+    const code = `$1 + 1 = 2$
+        \\(1 + 1 = 2\\)
+        $$1 + 1 = 2$$
+        \\[1 + 1 = 2\\]`;
+    const ast = LaTeX.Program.tryParse(code);
+    expect(ast.value[0].value.name).toBe("inlinemath");
+    expect(ast.value[2].value.name).toBe("inlinemath");
+    expect(ast.value[4].value.name).toBe("displaymath");
+    expect(ast.value[6].value.name).toBe("displaymath");
   });
 });
 

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -102,6 +102,7 @@ describe("Parsimmon AST", async () => {
     expect(top.name).toBe("figure");
     expect(top.body.value[1].value.name).toBe("minipage");
     expect(top.body.value[1].value.body.value[1].value.name).toBe("center");
+  });
   test("math", async () => {
     const code = `$1 + 1 = 2$
         \\(1 + 1 = 2\\)

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -108,10 +108,11 @@ describe("Parsimmon AST", async () => {
         $$1 + 1 = 2$$
         \\[1 + 1 = 2\\]`;
     const ast = LaTeX.Program.tryParse(code);
-    expect(ast.value[0].value.name).toBe("inlinemath");
-    expect(ast.value[2].value.name).toBe("inlinemath");
-    expect(ast.value[4].value.name).toBe("displaymath");
-    expect(ast.value[6].value.name).toBe("displaymath");
+    for(let i = 0; i <= 6; i += 2) {
+      const v = ast.value[i].value;
+      expect(v.name).toBe(i <= 2 ? "inlinemath" : "displaymath");
+      expect(v.body.value[0].value).toBe("1 + 1 = 2");
+    }
   });
 });
 


### PR DESCRIPTION
`$`〜`$`で囲まれたインライン数式がエラーになる問題を修正します。

`inlinemath.ts`の`Parsimmon.string("$$")`を修正すれば、エラーは解消します。
しかし、単に`$`でマッチさせると`$$`〜`$$`が二重のinlinemathとして解釈されてしまったため、正規表現で`$`1個のみにマッチする仕様としました。