### PR TITLE
Support more backslash commands

### DIFF
--- a/src/latex-to-ast/command/common.ts
+++ b/src/latex-to-ast/command/common.ts
@@ -26,7 +26,7 @@ export const Command = (r: Rules) => {
   const option = r.Option;
   const argument = r.Argument;
   const name = Parsimmon.regexp(
-    /\\(?!begin|end|verbatim|item)([a-zA-Z_@]+|[`'^"~=_#$%&{}\.\\ ])/,
+    /\\(?!begin|end|verbatim|item)([a-zA-Z_@]+|[`'^"~=_@#$%&{},\.\/\\ ])/,
     1
   );
   return Parsimmon.seqObj<CommandNode>(

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -115,8 +115,8 @@ describe("Parsimmon AST", async () => {
       expect(v.body.value[0].value).toBe("1 + 1 = 2");
     }
   });
-  test("symbols", async () => {
-    const symbols = ["#", "$", "%", "&", "_", "{", "}"];
+  test("commands for symbols, spaces, etc.", async () => {
+    const symbols = ["#", "@", "$", "%", "&", "_", "{", "}", ",", "/", " ", "\\"];
     const code = symbols.reduce((p, v) => p += "\\" + v, "")
     const ast = LaTeX.Program.tryParse(code);
     for(let i = 0; i < ast.value.length; ++i) {


### PR DESCRIPTION
fix #7 
`\,`, `\@`, `\/`をパース対象に追加します