### PR TITLE
Support other commands in list environments

### DIFF
--- a/src/latex-to-ast/environment/common.ts
+++ b/src/latex-to-ast/environment/common.ts
@@ -31,10 +31,11 @@ interface Context {
 
 export const BeginEnvironment = (
   pattern: string,
-  context: Context
+  context: Context,
+  additionalRegex: string = ''
 ): Parsimmon.Parser<string> =>
   Parsimmon((input, i) => {
-    const m = input.slice(i).match(new RegExp(`^\\\\begin\\{(${pattern})\\}`));
+    const m = input.slice(i).match(new RegExp(`^\\\\begin\\{(${pattern})\\}` + additionalRegex));
     if (m !== null) {
       if(context.name !== '') context.parents.push(context.name);
       context.name = m[1];

--- a/src/latex-to-ast/environment/list.ts
+++ b/src/latex-to-ast/environment/list.ts
@@ -38,7 +38,7 @@ export const List = (r: Rules) => {
     })
   );
   return Parsimmon.seqObj<EnvironmentNode>(
-    ["name", BeginEnvironment("itemize|enumerate", context, "([\\r\\n\\ ]*(\\\\(?!.*item\\ ).*))?")],
+    ["name", BeginEnvironment("itemize|enumerate", context, "(?:[\\r\\n\\ ]*(\\\\(?!.*item\\ ).*))?")],
     ["arguments", Parsimmon.alt(r.Option, r.Argument).many()],
     Parsimmon.whitespace,
     ["body", body],

--- a/src/latex-to-ast/environment/list.ts
+++ b/src/latex-to-ast/environment/list.ts
@@ -38,7 +38,7 @@ export const List = (r: Rules) => {
     })
   );
   return Parsimmon.seqObj<EnvironmentNode>(
-    ["name", BeginEnvironment("itemize|enumerate", context)],
+    ["name", BeginEnvironment("itemize|enumerate", context, "([\\r\\n\\ ]*(\\\\(?!.*item\\ ).*))?")],
     ["arguments", Parsimmon.alt(r.Option, r.Argument).many()],
     Parsimmon.whitespace,
     ["body", body],

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -66,15 +66,22 @@ describe("Parsimmon AST", async () => {
     });
   });
   test("Counting items", async () => {
-    const code = `\\begin{itemize}
-
-            \\item 1 \\command
-
-            \\item \\command 2
-
-        \\end{itemize}`;
-    const ast = LaTeX.Program.tryParse(code);
-    expect(ast.value[0].value.body.value.length).toBe(2);
+    const codes = [
+      `\\begin{itemize}
+         \\item 1 \\command
+         \\item \\command 2
+       \\end{itemize}`,
+      `\\begin{itemize}
+         \\itemsep1pt\\parskip0pt\\parsep0pt
+         \\item 1
+         \\item 2
+       \\end{itemize}`
+    ];
+    for(const code of codes) {
+      const ast = LaTeX.Program.tryParse(code);
+      expect(ast.value[0].value.name).toBe("itemize");
+      expect(ast.value[0].value.body.value.length).toBe(2);
+    }
   });
   test("figure environment", async () => {
     const code = `\\begin{figure}


### PR DESCRIPTION
fix #8 
様々な手法を試した結果、パースが成功するものがあったので提案いたします。

はじめ「先頭の非アイテム要素を無視する」方針で`environment/list.ts`に手を加えたものの、`\item`コマンドを読む部分だけではどうしても対処できませんでした。

今回問題となったのは`\begin{environment}`直後に`\item`ではないコマンドがある場合のみでした（それ以外の場合は`\item`のargumentとして扱われる）。
従って、`BeginEnvironment()`で無理やり非アイテムのコマンドまで読み取ってしまうようにしたところ、うまくパースできました。

正規表現のグループを分離しているため、`BeginEnvironment()`内での環境の名称の取得にも影響はないようです。