### PR TITLE
Add npm scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 src/**/*.js
 test/**/*.js
 package-lock.json
+lib/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "lint": "eslint src/**/*.ts",
     "build": "tsc",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "npm run build",
+    "prepublishOnly": "npm test"
   },
   "keywords": [
     "textlint",


### PR DESCRIPTION
prepareでビルドを、prepublishOnlyでテストを追加します。
これらは`npm publish`の実施前に必ず実行されるので、公開時のミスを防げます。

参考：[npm prepublish の現状と今後どう変わっていくか - Qiita](https://qiita.com/ndxbn/items/f0cd2b13a3268254f2aa)