### PR TITLE
replace "Foobar" with "textlint-plugin-latex2e"

### DIFF
--- a/src/LaTeXProcessor.ts
+++ b/src/LaTeXProcessor.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 import {
   TextlintPluginProcessor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { LaTeXProcessor } from "./LaTeXProcessor";
 import { TextlintPluginCreator } from "@textlint/types";

--- a/src/latex-to-ast/argument.ts
+++ b/src/latex-to-ast/argument.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/command/common.ts
+++ b/src/latex-to-ast/command/common.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Rules } from "../rules";
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/command/index.ts
+++ b/src/latex-to-ast/command/index.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 export { CommandNode, Command } from "./common";
 export { Verbatim } from "./verbatim";

--- a/src/latex-to-ast/command/verbatim.ts
+++ b/src/latex-to-ast/command/verbatim.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { Rules } from "../rules";
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/comment.ts
+++ b/src/latex-to-ast/comment.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/emptyline.ts
+++ b/src/latex-to-ast/emptyline.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/environment/common.ts
+++ b/src/latex-to-ast/environment/common.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/environment/displaymath.ts
+++ b/src/latex-to-ast/environment/displaymath.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/environment/document.ts
+++ b/src/latex-to-ast/environment/document.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 import Parsimmon from "parsimmon";
 import { EnvironmentNode, BeginEnvironment, EndEnvironment } from "./common";

--- a/src/latex-to-ast/environment/figure.ts
+++ b/src/latex-to-ast/environment/figure.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/environment/index.ts
+++ b/src/latex-to-ast/environment/index.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 export { DisplayMath } from "./displaymath";
 export { Environment } from "./common";

--- a/src/latex-to-ast/environment/inlinemath.ts
+++ b/src/latex-to-ast/environment/inlinemath.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 import Parsimmon from "parsimmon";
 import { Rules } from "../rules";

--- a/src/latex-to-ast/environment/list.ts
+++ b/src/latex-to-ast/environment/list.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/index.ts
+++ b/src/latex-to-ast/index.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import { LaTeX } from "./latex";

--- a/src/latex-to-ast/latex.ts
+++ b/src/latex-to-ast/latex.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/option.ts
+++ b/src/latex-to-ast/option.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/rules.ts
+++ b/src/latex-to-ast/rules.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";

--- a/src/latex-to-ast/text.ts
+++ b/src/latex-to-ast/text.ts
@@ -1,18 +1,18 @@
 /*
  * This file is part of textlint-plugin-latex2e
  *
- * Foobar is free software: you can redistribute it and/or modify
+ * textlint-plugin-latex2e is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Foobar is distributed in the hope that it will be useful,
+ * textlint-plugin-latex2e is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with Foobar.  If not, see <http://www.gnu.org/licenses/>.
+ * along with textlint-plugin-latex2e.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 import Parsimmon from "parsimmon";


### PR DESCRIPTION
ファイル先頭のソフトウェア名称が仮のままになっているため置換しました。